### PR TITLE
Grow buffer exponentially

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ Writer.prototype._ensure = function(size) {
   var remaining = this.buffer.length - this.offset;
   if(remaining < size) {
     var oldBuffer = this.buffer;
-    this.buffer = new Buffer(oldBuffer.length + size);
+    // exponential growth factor of around ~ 1.5
+    // https://stackoverflow.com/questions/2269063/buffer-growth-strategy
+    var newSize = oldBuffer.length + (oldBuffer.length >> 1) + size;
+    this.buffer = new Buffer(newSize);
     oldBuffer.copy(this.buffer);
   }
 };


### PR DESCRIPTION
If the buffer is not exponentially grown, there is a severe drop in performance when sending a large query with many parameters 

For example, a large insert query of a 10k item array created with node-sql takes 1/2 minute

With this change, the insert executes in 0.6s (40x improvement)

A factor of 1.5 is considered a good balance between performance and wasted memory (also, for some types of memory allocators any factor bigger than 1.6 has considerably worse characteristics)
